### PR TITLE
Move definition of url_base variable to inside stream classes

### DIFF
--- a/tap_klaviyo_custom/streams.py
+++ b/tap_klaviyo_custom/streams.py
@@ -21,8 +21,6 @@ LOGGER = singer.get_logger()
 
 SCHEMAS_DIR = Path(__file__).parent / Path("./schemas")
 
-url_base = 'https://a.klaviyo.com/api/v2/'
-
 
 class ListsStream(RESTStream):
     """Define custom stream."""
@@ -31,6 +29,7 @@ class ListsStream(RESTStream):
     primary_keys = ["list_id"]
     replication_key = None
     schema_filepath = SCHEMAS_DIR / "lists.json"
+    url_base = 'https://a.klaviyo.com/api/v2/'
 
     records_jsonpath = "$[*]"  # Or override `parse_response`.
 
@@ -87,6 +86,7 @@ class ListMembersStream(RESTStream):
     primary_keys = ["email"]
     replication_key = None
     schema_filepath = SCHEMAS_DIR / "list_members.json"
+    url_base = 'https://a.klaviyo.com/api/v2/'
 
     records_jsonpath = "$[*]"  # Or override `parse_response`.
 

--- a/tap_klaviyo_custom/streams.py
+++ b/tap_klaviyo_custom/streams.py
@@ -29,6 +29,7 @@ class ListsStream(RESTStream):
     primary_keys = ["list_id"]
     replication_key = None
     schema_filepath = SCHEMAS_DIR / "lists.json"
+    #Defining the url_base outside of the class results in an error
     url_base = 'https://a.klaviyo.com/api/v2/'
 
     records_jsonpath = "$[*]"  # Or override `parse_response`.
@@ -86,6 +87,7 @@ class ListMembersStream(RESTStream):
     primary_keys = ["email"]
     replication_key = None
     schema_filepath = SCHEMAS_DIR / "list_members.json"
+    #Defining the url_base outside of the class results in an error
     url_base = 'https://a.klaviyo.com/api/v2/'
 
     records_jsonpath = "$[*]"  # Or override `parse_response`.

--- a/tap_klaviyo_custom/streams.py
+++ b/tap_klaviyo_custom/streams.py
@@ -21,6 +21,8 @@ LOGGER = singer.get_logger()
 
 SCHEMAS_DIR = Path(__file__).parent / Path("./schemas")
 
+url_base = 'https://a.klaviyo.com/api/v2/'
+
 
 class ListsStream(RESTStream):
     """Define custom stream."""
@@ -72,7 +74,7 @@ class ListsStream(RESTStream):
 
         Developers override this method to perform dynamic URL generation.
         """
-        url = self.config['url_base']+self.path
+        url = self.url_base+self.path
 
         return url
 
@@ -131,7 +133,7 @@ class ListMembersStream(RESTStream):
 
         Developers override this method to perform dynamic URL generation.
         """
-        url = self.config['url_base']+self.path.format(list_id=list_id)
+        url = self.url_base+self.path.format(list_id=list_id)
 
         return url
 

--- a/tap_klaviyo_custom/tap.py
+++ b/tap_klaviyo_custom/tap.py
@@ -23,8 +23,7 @@ class Tapklaviyo_custom(Tap):
     config_jsonschema = th.PropertiesList(
         th.Property("auth_token", th.StringType, required=False),
         th.Property("start_date", th.DateTimeType),
-        th.Property("api_url", th.StringType, default="https://a.klaviyo.com/api/v2/"),
-        th.Property("url_base", th.StringType, required=True)
+        th.Property("api_url", th.StringType, default="https://a.klaviyo.com/api/v2/")
     ).to_dict()
 
     def discover_streams(self) -> List[Stream]:

--- a/tap_klaviyo_custom/tap.py
+++ b/tap_klaviyo_custom/tap.py
@@ -24,6 +24,7 @@ class Tapklaviyo_custom(Tap):
         th.Property("auth_token", th.StringType, required=False),
         th.Property("start_date", th.DateTimeType),
         th.Property("api_url", th.StringType, default="https://a.klaviyo.com/api/v2/"),
+        th.Property("url_base", th.StringType, required=True)
     ).to_dict()
 
     def discover_streams(self) -> List[Stream]:


### PR DESCRIPTION
Before, this variable was defined inside of the config of the project's meltano.yml file, however this resulted in an error. The same error happened when the variable was defined globally inside streams.py